### PR TITLE
[fix] Do not throw when unmount is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -301,7 +301,7 @@ export default class Measure extends Component {
     const end = this.get('loadEventEnd');
     const rum = {};
 
-    if (!start || !end) return this.reset();
+    if (!start || !end || !unmount) return this.reset();
 
     //
     // Start of the route loading.


### PR DESCRIPTION
Do not throw if we no longer receive the required data from Next, they introduced an undocumented breaking change https://github.com/vercel/next.js/pull/13156 that causes a JS error to be thrown on the page.

For now, functionality will not work as expected until similar hooks are introduced into said project, but at least we're no longer throwing an error as a result of it.